### PR TITLE
Allow executable path option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,14 +161,21 @@ const getDomainName = async (page, uri) => {
 module.exports = async (
   uri,
   puppeteerArgs = [],
-  puppeteerAgent = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
+  puppeteerAgent = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
+  executablePath
 ) => {
   puppeteer.use(pluginStealth());
-  const browser = await puppeteer.launch({
+
+  const params = {
     headless: true,
     args: [...puppeteerArgs],
-  });
-  const page = await browser.newPage();
+  };
+  if (executablePath) {
+    params["executablePath"] = executablePath;
+  }
+
+  const browser = await puppeteer.launch(params);
+  const page = await browser.newPage(params);
   page.setUserAgent(puppeteerAgent);
 
   await page.goto(uri);

--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ module.exports = async (
   }
 
   const browser = await puppeteer.launch(params);
-  const page = await browser.newPage(params);
+  const page = await browser.newPage();
   page.setUserAgent(puppeteerAgent);
 
   await page.goto(uri);


### PR DESCRIPTION
This will allow the use of a specific chrome executable in the case for example of executing puppeteer in an aws lambda with chrome-aws-lambda