### PR TITLE
TypeScript type defs + Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,20 @@ Type: `string`
 Specific user agent to use.
 
 ## Troubleshooting
-
 If you need to deploy this library (Puppeteer) on Heroku, follow [these steps](https://stackoverflow.com/a/55090914/968379).
+
+If you want to run this library from within a Docker container:
+1. pass the following puppeteer arguments as second argument
+```json
+// Required for Docker version of Puppeteer
+'--no-sandbox',
+'--disable-setuid-sandbox',
+// This will write shared memory files into /tmp instead of /dev/shm,
+// because Docker’s default for /dev/shm is 64MB
+'--disable-dev-shm-usage'
+```
+2. make sure your Docker image has all needed dependencies for headless chrome or just go straight away with [buildkite/puppeteer](https://hub.docker.com/r/buildkite/puppeteer/dockerfile)
+3. done
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+export = link_preview_generator;
+
+declare function link_preview_generator(
+    uri: string,
+    puppeteerArgs: string[],
+    puppeteerAgent: string,
+    executablePath: string
+): LinkPreviewResult;
+
+declare interface LinkPreviewResult {
+    title: string;
+    description: string;
+    domain: string;
+    img: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "link-preview-generator",
-  "version": "0.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "get-urls": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
     "puppeteer-extra": "^3.1.18",
     "puppeteer-extra-plugin-stealth": "^2.7.6",
     "request": "^2.88.2"
-  }
+  },
+  "types": "./index.d.ts"
 }


### PR DESCRIPTION
This adds some rudimentary TypeScript definitions for the main exported function in order to please TS when consuming this library.

Additionally I went ahead and added some instructions for running this in Docker, based on [this issue](https://github.com/AndrejGajdos/link-preview-generator/issues/4)