### PR TITLE
fix type definition of link_preview_generator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,10 +2,10 @@ export = link_preview_generator;
 
 declare function link_preview_generator(
     uri: string,
-    puppeteerArgs: string[],
-    puppeteerAgent: string,
-    executablePath: string
-): LinkPreviewResult;
+    puppeteerArgs?: string[],
+    puppeteerAgent?: string,
+    executablePath?: string
+): Promise<LinkPreviewResult>;
 
 declare interface LinkPreviewResult {
     title: string;


### PR DESCRIPTION
I've updated the type definitions for typescript since the current definitions don't work for me.

`puppeteerArgs` and `puppeteerAgent` have defaults

`executablePath` is accessed behind an if

return value is an async function -> `Promise<..>`