### PR TITLE
Get a favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ console.log(previewData);
     'improve your style and make this basic your own. ' +
     'Sessio...',
   domain: 'youtube.com',
-  img: 'https://i.ytimg.com/vi/8mqqY2Ji7_g/hqdefault.jpg'
+  img: 'https://i.ytimg.com/vi/8mqqY2Ji7_g/hqdefault.jpg',
+  favicon: 'https://www.youtube.com/s/desktop/d3411c39/img/favicon.ico'
 }
 */
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,4 +12,5 @@ declare interface LinkPreviewResult {
     description: string;
     domain: string;
     img: string;
+    favicon: string;
 }


### PR DESCRIPTION
## Description

Implementation proposal for https://github.com/AndrejGajdos/link-preview-generator/issues/25

## Algorithm to determine a favicon

In conclusion, I implemented an algorithm to get a favicon with the following priorities.

1. A `favicon.ico` placed in the root directory that is not associated with the link tag
2. A favicon whose rel attribute value of the link tag is "icon" and whose sizes attribute value is "16x16".
3. A favicon whose rel attribute value of the link tag is "shortcut icon"
4. A favicon whose rel attribute value of the link tag is "icon" at the top of the document
5. A favicon whose rel attribute value of the link tag is "apple-touch-icon" or "apple-touch-icon-precomposed" at the top of the document

## Basis of the algorithm

According to [Favicon CheatSheet](https://github.com/audreyfeldroy/favicon-cheat-sheet), many browsers (Opera, Safari, Chrome, Firefox, IE 5+) lookup directly for the `favicon.ico` located in the root directory by default, regardless of the link tag. So even in this implementation, we preferentially get the `favicon.ico` directly.

[HTML5 specification](https://html.spec.whatwg.org/multipage/links.html#rel-icon) specifies favicons with the value of the rel attribute of the link tag as "icon". We refer to the favicons if the `favicon.ico` in the root directory is not found.

```html
<head>
  <link rel="icon" href="favicon.png" sizes="16x16" type="image/png" />
</head>
```

The actual implementation of websites is often different from HTML5 specification, e.g. Youtube looks like this:

```html
<head>
  <link
    rel="shortcut icon"
    href="https://www.youtube.com/s/desktop/5650b92e/img/favicon.ico"
    type="image/x-icon"
  />
  <link
    rel="icon"
    href="https://www.youtube.com/s/desktop/5650b92e/img/favicon_32x32.png"
    sizes="32x32"
  />
  <link
    rel="icon"
    href="https://www.youtube.com/s/desktop/5650b92e/img/favicon_48x48.png"
    sizes="48x48"
  />
  <link
    rel="icon"
    href="https://www.youtube.com/s/desktop/5650b92e/img/favicon_96x96.png"
    sizes="96x96"
  />
  <link
    rel="icon"
    href="https://www.youtube.com/s/desktop/5650b92e/img/favicon_144x144.png"
    sizes="144x144"
  />
</head>
```

I refer to [Google Search Central Favicon Guideline](https://developers.google.com/search/docs/advanced/appearance/favicon-in-search) to determine favicons. we recognize resources whose value of the rel attribute of the link tag takes the following values as favicon

- shortcut icon
- icon
- apple-touch-icon
- apple-touch-icon-precomposed

If there are multiple favicons associated with the link tag, the one with the highest possibility of being small is given priority.

## Test

I used a [sample site](https://github.com/koukikitamura/link-preview-sample-site) for testing.

- [x] Return the `favicon.ico` in the root directory if the link tag does not specify favicons.
- [x] Return the `favicon.ico` in the root directory if the link tag specifies favicons.
- [x] Return a favicon associated with the link tag if the `favicon.ico` does not exist
- [x] Return null value if the `favicon.ico` in the root directory does not exist and favicons are not associated with the link tag.
